### PR TITLE
feat: improve brew release

### DIFF
--- a/.github/workflows/brew-release.yml
+++ b/.github/workflows/brew-release.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
       - name: Get Ruby file
         id: get_ruby_file
-        run: curl -o siera.rb https://raw.githubusercontent.com/animo/homebrew-siera/main/Formula/siera.rb
+        run: |
+          git clone https://github.com/animo/homebrew-siera.git
+          cp ./homebrew-siera/Formula/siera.rb ./siera.rb
       - name: Gather data and rewrite ruby file
         id: gather_data_and_rewrite
         run: |


### PR DESCRIPTION
uses git clone instead of curl to get the Homebrew Ruby file. This should improve the release because the curl can no longer succeed with non 200 response code. instead the step should fail if git clone and copy file fails.

Signed-off-by: Moriarty <moritz@animo.id>

closes #234 